### PR TITLE
add utteranc.es support for posts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,11 @@ params:
     Creative Commons Attribution 4.0 International License</a>.
   rss: To subscribe to this RSS feed, copy its address and paste it into your
     favorite feed reader.
+  utterances:
+    repo: ""
+    issueTerm: "pathname"
+    theme: "github-light"
+    crossorigin: "anonymous"
 
 menu:
   nav:

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,9 +1,20 @@
 {{ define "main" }}
 
 <article>
-  {{ partial "heading.html" . }}
-  {{ .Content }}
-  {{ partial "tags.html" . }}
+    {{ partial "heading.html" . }}
+    {{ .Content }}
+    {{ partial "tags.html" . }}
+    {{if eq .Type "posts" }}
+    {{ with .Site.Params.utterances }}
+    <script src="https://utteranc.es/client.js"
+            repo="{{ .repo }}"
+            issue-term="{{ .issueterm }}"
+            theme="{{ .theme }}"
+            crossorigin="{{ .crossorigin }}"
+            async>
+    </script>
+    {{end}}
+    {{end}}
 </article>
 
 {{ end }}


### PR DESCRIPTION
this adds [utteranc.es](https://utteranc.es/) support for content type "posts".

i am not sure if thats the way this should be done - its my first time using
 hugo/go templates, and i would not call myself a frontend developer.
feel free to suggest changes, or just close if you dont want it at all. :)

this is how it looks: http://puhoy.github.io/posts/syncthing_protocol_buffers/
