### PR TITLE
add option to show summary in main section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Configuration options may be copied and modified from the theme defaults:
 
 ```yaml
 params:
+  mainSections: posts  # Main content folder
+  summary: false # Display main content as summary
   color: teal  # Any color in CSS syntax
   width: 42rem  # Any length in CSS syntax
   footer: Except where otherwise noted, content on this site is licensed under

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,6 @@
 params:
+  mainSections: posts  # Main content folder
+  summary: false # Display main content as summary
   color: teal  # Any color in CSS syntax
   width: 42rem  # Any length in CSS syntax
   footer: Except where otherwise noted, content on this site is licensed under

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -26,7 +26,7 @@
         <a href="{{ .RelPermalink }}">Read More…</a>
       </div>
     {{ end }}
-    {{ else }}
+  {{ else }}
     {{ .Content }}
   {{ end }}
   {{ partial "tags.html" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -19,7 +19,16 @@
 {{ range $paginator.Pages }}
 <article>
   {{ partial "heading.html" . }}
-  {{ .Content }}
+  {{ if site.Params.summary }}
+    {{ .Summary }}
+    {{ if .Truncated }}
+      <div>
+        <a href="{{ .RelPermalink }}">Read More…</a>
+      </div>
+    {{ end }}
+    {{ else }}
+    {{ .Content }}
+  {{ end }}
   {{ partial "tags.html" . }}
 </article>
 {{ end }}


### PR DESCRIPTION
This PR adds an option to display summaries instead of whole articles on the main page, as described here: https://gohugo.io/content-management/summaries/#example-first-10-articles-with-summaries
