### PR TITLE
Include meta description tag in <head>

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,6 +3,13 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  {{ if .Summary }}
+  <meta name="description" content="{{ .Summary }}">
+  {{ else }}
+  {{ with site.Params.description }}
+  <meta name="description" content="{{ . }}">
+  {{ end }}
+  {{ end }}
   {{ hugo.Generator }}
   {{ if site.Params.schema }}{{ template "_internal/schema.html" . }}{{ end }}
   {{ if site.Params.opengraph }}{{ template "_internal/opengraph.html" . }}{{ end }}


### PR DESCRIPTION
This puts the page's `.Summary` in a `<meta>` description tag for individual pages and includes the (optional) site description if the page does not have a `.Summary`.