### PR TITLE
Include <head> data in a separate partial

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,20 +1,7 @@
 <!DOCTYPE html>
 <html lang="{{ site.LanguageCode }}">
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  {{ hugo.Generator }}
-  {{ if site.Params.schema }}{{ template "_internal/schema.html" . }}{{ end }}
-  {{ if site.Params.opengraph }}{{ template "_internal/opengraph.html" . }}{{ end }}
-  {{ if site.Params.twittercards }}{{ template "_internal/twitter_cards.html" . }}{{ end }}
-  <title>
-    {{ if eq .Title site.Title }}
-    {{ site.Title }}
-    {{ else }}
-    {{ with .Title }}{{ . }} | {{ end }}{{ site.Title }}
-    {{ end }}
-  </title>
-  <link rel="canonical" href="{{ .Permalink }}">
+  {{ partial "head.html" . }}
   {{ range .AlternativeOutputFormats }}
   {{ printf "<link rel=%q type=%q href=%q title=%q>" .Rel .MediaType .Permalink site.Title | safeHTML }}
   {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,14 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+{{ hugo.Generator }}
+{{ if site.Params.schema }}{{ template "_internal/schema.html" . }}{{ end }}
+{{ if site.Params.opengraph }}{{ template "_internal/opengraph.html" . }}{{ end }}
+{{ if site.Params.twittercards }}{{ template "_internal/twitter_cards.html" . }}{{ end }}
+<title>
+  {{ if eq .Title site.Title }}
+  {{ site.Title }}
+  {{ else }}
+  {{ with .Title }}{{ . }} | {{ end }}{{ site.Title }}
+  {{ end }}
+</title>
+<link rel="canonical" href="{{ .Permalink }}">


### PR DESCRIPTION
This allows theme users to easily customize what they want to include in
the <head> of their documents.