### PR TITLE
Add math support to the theme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ As an example, this is the template for the built-in Soundcloud shortcode:
 
 ### Math Display
 
-To enable math display in a certian post, add 
+To enable math display in a certain post, add 
 
 ```yaml
 ---

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Optional features:
 - Schema.org, Open Graph and Twitter Cards metadata
 - Utterances comments widget
 - Custom CSS and JS can be added [site-wide](#custom-css-and-js), or [dynamically](#dynamically-embedded) with shortcodes
+- Math display with Katex
 - Built-in shortcodes:
   - Netlify contact form
   - On-click Soundcloud player
@@ -168,6 +169,23 @@ As an example, this is the template for the built-in Soundcloud shortcode:
 {{ resources.Get "js/soundcloud.js" | minify | fingerprint  | .Page.Scratch.SetInMap "js" "soundcloud" }}
 <div class="Soundcloud" data-id="{{ .Get 0 }}"></div>
 ```
+
+### Math Display
+
+To enable math display in a certian post, add 
+
+```yaml
+---
+katex: true
+markup: "mmark"
+---
+```
+
+to your markdown file front matter lines.
+
+It will enable both inline math and math block display only in one post, using `$$...$$` as math delimiter.
+
+**Note:** Although mmark is described as depricated in the Hugo docs, it is the only markdown library that has fully math support, other library like Goldmark only supports math block typesetting.
 
 ## License
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,6 +10,7 @@
     {{ with .Content }}{{ end }}
   {{ end }}
   {{ partial "assets.html" . }}
+  {{ if .Params.katex}}{{ partial "katex.html" . }}{{ end }}
 </head>
 
 <body>

--- a/layouts/partials/katex.html
+++ b/layouts/partials/katex.html
@@ -1,0 +1,9 @@
+<!-- CSS -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
+
+<!-- The loading of KaTeX is deferred to speed up page rendering -->
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js" integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4" crossorigin="anonymous"></script>
+
+<!-- To automatically render math in text elements, include the auto-render extension: -->
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js" integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa" crossorigin="anonymous"
+        onload="renderMathInElement(document.body);"></script>


### PR DESCRIPTION
Love this theme! I am using it for my personal blog!
This should add math support to the theme.

* Add a standalone `katex.html` partial, it imports [Katex](https://katex.org/).
* Add a `if` in the `<head>` section to determine whether to include the partial.
* Update README.md.