### PR TITLE
tell robots no[index,archive,follow] for paginator

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,5 +1,9 @@
 <meta charset="utf-8">
 
+{{ if and (eq .RelPermalink "/") (ne .Paginator.PageNumber 1) }}
+<meta name="robots" content="noindex,noarchive,nofollow" />
+{{ end }}
+
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 {{ with .Description }}


### PR DESCRIPTION
Search engines will index paginator pages and serve results that may no longer contain the desired article for frequently updated blogs.
Also, for larger sites, avoid wasting robots time on pages it already has via the "blog" listing.

This excludes URLs page/2 page/3 and so on