### PR TITLE
header option 'noindex' to tell robots no[index,archive]

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,5 +1,9 @@
 <meta charset="utf-8">
 
+{{ if .Params.noindex }}
+<meta name="robots" content="noindex,noarchive" />
+{{ end }}
+
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 {{ with .Description }}


### PR DESCRIPTION
this allows an easy per-page way in the header front matter to
exclude a page from robots with parameter "noindex: true"