### PR TITLE
add google analytics 4 option

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,6 +3,9 @@
 
 <head>
   {{ block "load_paginator" . }}{{ end }}
+  {{ if and (not .Site.IsServer) .Site.GoogleAnalytics }}
+    {{ template "_internal/google_analytics.html" . }}
+  {{ end }}
   {{ partial "meta.html" . }}
   {{ partial "title.html" . }}
   {{ partial "link.html" . }}


### PR DESCRIPTION
enabled only when not on local server "Hugo serve" to avoid clogging analytics with developer preview on their laptop.

Uses built-in Hugo [factory support](https://gohugo.io/templates/internal/) for Google Analytics 4.